### PR TITLE
Cleanup in on-client-disconnect

### DIFF
--- a/src/ring/sse.clj
+++ b/src/ring/sse.clj
@@ -107,17 +107,19 @@
                              (ring-response/header "Connection" "close")
                              (ring-response/header "Cache-Control" "no-cache"))
         ;; TODO: re-create CORS support as per original: (update-in [:headers] merge (:cors-headers context))
-        event-channel    (async/chan (if (fn? bufferfn-or-n) (bufferfn-or-n) bufferfn-or-n))]
-    (respond response)
-    (async/thread
-      (stream-ready-fn request response raise event-channel)
-      :done)
+        event-channel    (async/chan (if (fn? bufferfn-or-n) (bufferfn-or-n) bufferfn-or-n))
+        _                (respond response)
+        sr-fn-res-chan   (async/thread
+                           (stream-ready-fn request
+                                            response
+                                            raise
+                                            event-channel))]
     (start-dispatch-loop (merge {:event-channel    event-channel
                                  :response-channel response-channel
                                  :heartbeat-delay  heartbeat-delay
                                  :raise            raise}
                                 (when on-client-disconnect
-                                  {:on-client-disconnect #(on-client-disconnect response)})))))
+                                  {:on-client-disconnect #(on-client-disconnect response sr-fn-res-chan)})))))
 
 (defn event-channel-handler
   "Returns a Ring async handler which will start a Server Sent Event

--- a/src/ring/sse.clj
+++ b/src/ring/sse.clj
@@ -119,7 +119,14 @@
                                  :heartbeat-delay  heartbeat-delay
                                  :raise            raise}
                                 (when on-client-disconnect
-                                  {:on-client-disconnect #(on-client-disconnect response sr-fn-res-chan)})))))
+                                  (if (== 1 (-> on-client-disconnect
+                                                class
+                                                .getDeclaredMethods
+                                                first
+                                                .getParameterTypes
+                                                alength))
+                                    {:on-client-disconnect #(on-client-disconnect response)}
+                                    {:on-client-disconnect #(on-client-disconnect response sr-fn-res-chan)}))))))
 
 (defn event-channel-handler
   "Returns a Ring async handler which will start a Server Sent Event


### PR DESCRIPTION
We have to make some cleanup of resources created in `stream-ready-fn`.
(Specifically, we need to `untap` some channels, which were tapped in `stream-ready-fn`. Because when not untapped, this channels block main event channel.)

With this change we can return anything from `stream-ready-fn` and then handle it in `on-client-disconnect` (by consuming channel returned by `core.async/thread`).

To not break backwards compatibility, we check for `on-client-disconnect` arity.